### PR TITLE
ENH: add option to opt-out of reporting

### DIFF
--- a/popylar/popylar.py
+++ b/popylar/popylar.py
@@ -1,12 +1,34 @@
 import os.path as op
 import requests
+import uuid
 
 popylar_path = op.join(op.expanduser('~'), '.popylar')
+DO_NOT_TRACK = 'DO_NOT_TRACK'
 
 
-def get_uid():
+def opt_out():
+    """Permanently opt-out of Popylar tracking.
+
+    To opt-in again, run ``popylar.reset_uid()``
+    """
+    with open(popylar_path, 'w') as fhandle:
+        fhandle.write(DO_NOT_TRACK)
+
+
+def reset_uid():
+    """Opt-in to popylar tracking, and/or reset the user id"""
+    uid = uuid.uuid1()
+    with open(popular_path, 'w') as fhandle:
+        fhandle.write(uid.hex)
+
+
+def _get_uid():
     if op.exists(popylar_path):
         return open(popylar_path).read()
+        if uid.strip() == DO_NOT_TRACK:
+            return False
+        else:
+            return uid
     else:
         return False
 
@@ -33,10 +55,10 @@ def track_event(tracking_id, category, action, uid=None, label=None, value=0,
     """
     # If no user unique ID provided, try to get one from popylar_path:
     if uid is None:
-        uid = get_uid()
+        uid = _get_uid()
 
-    # If it's stil None, assume that the user has opted out (by removing that
-    # file):
+    # If it's stil None, assume that the user has opted out
+    # (either by removing the file or running popylar.opt_out())
     if not uid:
         return False
 

--- a/popylar/popylar.py
+++ b/popylar/popylar.py
@@ -22,9 +22,15 @@ def reset_uid():
         fhandle.write(uid.hex)
 
 
+def opt_in():
+    """Opt-in to popylar tracking"""
+    if not _get_uid():
+        reset_uid()
+
+
 def _get_uid():
     if op.exists(popylar_path):
-        return open(popylar_path).read()
+        uid = open(popylar_path).read()
         if uid.strip() == DO_NOT_TRACK:
             return False
         else:

--- a/popylar/popylar.py
+++ b/popylar/popylar.py
@@ -18,7 +18,7 @@ def opt_out():
 def reset_uid():
     """Opt-in to popylar tracking, and/or reset the user id"""
     uid = uuid.uuid1()
-    with open(popular_path, 'w') as fhandle:
+    with open(popylar_path, 'w') as fhandle:
         fhandle.write(uid.hex)
 
 

--- a/setup.py
+++ b/setup.py
@@ -8,11 +8,14 @@ with open(ver_file) as f:
     exec(f.read())
 
 popylar_path = op.join(op.expanduser('~'), '.popylar')
-uid = uuid.uuid1()
 
-fhandle = open(popylar_path, 'a')
-fhandle.write(uid.hex)
-fhandle.close()
+# If UID file does not exist, then generate a UID and save to file.
+# We don't overwrite an existing one in order to keep UIDs constant
+# when the package is upgraded or installed in a venv.
+if not os.path.exists(popylar_path):
+    uid = uuid.uuid1()
+    with open(popylar_path, 'a') as fhandle:
+        fhandle.write(uid.hex)
 
 PACKAGES = find_packages()
 


### PR DESCRIPTION
This allows a user to run

```python
import popylar
popylar.opt_out()
```

to permanently opt-out of reporting, even if popylar is installed again. To opt back in, the user can run

```python
import popylar
popylar.reset_uid()
```

Though as I type this, I'm realizing we should have an ``opt_in`` function for symmetry.