### PR TITLE
Require "requests[security]" instead of just "requests"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-requests
+requests[security]


### PR DESCRIPTION
To avoid this:

http://stackoverflow.com/questions/29099404/ssl-insecureplatform-error-when-using-requests-package