### PR TITLE
Changed the use of configparser to make it consistent in python 2 and 3

### DIFF
--- a/popylar/popylar.py
+++ b/popylar/popylar.py
@@ -1,20 +1,19 @@
 import os.path as op
 import requests
 import uuid
-import configparser
+from configparser import ConfigParser
 
 popylar_path = op.join(op.expanduser('~'), '.popylar')
 
 
 def get_or_create_config():
     if not op.exists(popylar_path):
-        parser = configparser.ConfigParser()
-        parser.read_dict(dict(user=dict(uid=uuid.uuid1().hex,
-                                        track=True)))
+        default_dict = dict(user=dict(uid=uuid.uuid1().hex, track=True))
+        parser = ConfigParser(default_dict)
         with open(popylar_path, 'w') as fhandle:
             parser.write(fhandle)
     else:
-        parser = configparser.ConfigParser()
+        parser = ConfigParser()
         parser.read(popylar_path)
 
     return parser

--- a/setup.py
+++ b/setup.py
@@ -14,10 +14,10 @@ popylar_path = op.join(op.expanduser('~'), '.popylar')
 # If UID file does not exist, then generate a UID and save to file.
 # We don't overwrite an existing one in order to keep UIDs constant
 # when the package is upgraded or installed in a venv.
+
 if not os.path.exists(popylar_path):
-    parser = configparser.ConfigParser()
-    parser.read_dict(dict(user=dict(uid=uuid.uuid1().hex,
-                                    track=True)))
+    default_dict = dict(user=dict(uid=uuid.uuid1().hex,  track=True))
+    parser = configparser.ConfigParser(default_dict)
     with open(popylar_path, 'w') as fhandle:
         parser.write(fhandle)
 


### PR DESCRIPTION
This addresses the problems of running the setup for popylar in python 2.7 when the `~/.popylar` file did not already exist.

It seems that the `read_dict` method of `ConfigParser` only exists in python 3, and therefore using 
`ConfigParser(default_dict)` works on both python 2 and 3 rather than `ConfigParser.read_dict(default_dict)` which only works in python 3.

I am not sure why the python tests passed in python 2.7 in the previous case (maybe it did not clean up the ~/.popylar file created by running the test on python 3?) 
        modified:   popylar/popylar.py
	modified:   setup.py

Fixes #20