### PR TITLE
NF: Run the request on a separate thread.

### DIFF
--- a/popylar/tests/test_popylar.py
+++ b/popylar/tests/test_popylar.py
@@ -5,8 +5,15 @@ def test_track_event():
     """
     Test that event tracking goes through
     """
-    r = popylar.track_event("UA-86484662-2", 'test', 'test_track_event')
+    r = popylar.track_event("UA-86484662-2", 'test', 'test_track_event',
+                            thread=False)
+    # When not threading, we can can check the status of the request:
     assert r.status_code == 200, "response is not OK"
+
+    r = popylar.track_event("UA-86484662-2", 'test', 'test_track_event',
+                            thread=True)
+    # Otherwise the return value is none
+    assert r is None, "There should be nothing to see here"
 
 
 def test_track_event_with_version():
@@ -16,8 +23,15 @@ def test_track_event_with_version():
     from popylar.version import VERSION
     r = popylar.track_event("UA-86484662-2", 'test',
                             'test_track_event_with_version',
-                            software_version=VERSION)
+                            software_version=VERSION, thread=False)
+    # When not threading, we can can check the status of the request:
     assert r.status_code == 200, "response is not OK"
+
+    r = popylar.track_event("UA-86484662-2", 'test',
+                            'test_track_event_with_version',
+                            software_version=VERSION, thread=True)
+    # Otherwise the return value is none
+    assert r is None, "There should be nothing to see here"
 
 
 def test_opt():


### PR DESCRIPTION
This complicates the return from the function a bit. I left it as an option to return the request, so that we can occasionally check that everything is OK. But the default behavior is to spawn a new thread, and not wait around for it to be done. I am not sure how to test that everything is OK on that thread, though, without obstructing it.